### PR TITLE
feat: accept renderMinimap prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-virtualized-flowchart",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Flowchart",
   "keywords": [],
   "homepage": "https://chinmayhem.github.io/react-virtualized-flowchart",

--- a/src/Diagram.js
+++ b/src/Diagram.js
@@ -472,6 +472,7 @@ Diagram.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  renderMinimap: PropTypes.func,
 };
 
 Diagram.defaultProps = {

--- a/src/Diagram.js
+++ b/src/Diagram.js
@@ -367,6 +367,21 @@ class Diagram extends React.PureComponent {
       height: viewport.yMax - viewport.yMin,
     };
 
+    if (this.props.renderMinimap) {
+      return (
+        <React.Fragment>
+          {this.props.renderMinimap({
+            vertices: this.props.vertices,
+            extremeX: Math.max(extremeX, width),
+            extremeY: Math.max(extremeY, height),
+            viewport: minimapViewport,
+            zoom,
+            changeScrollHandler: this.scrollToPosition,
+          })}
+        </React.Fragment>
+      );
+    }
+
     return (
       <Minimap
         vertices={this.props.vertices}

--- a/src/Diagram.js
+++ b/src/Diagram.js
@@ -367,31 +367,20 @@ class Diagram extends React.PureComponent {
       height: viewport.yMax - viewport.yMin,
     };
 
+    const minimapProps = {
+      vertices: this.props.vertices,
+      extremeX: Math.max(extremeX, width),
+      extremeY: Math.max(extremeY, height),
+      viewport: minimapViewport,
+      zoom,
+      changeScrollHandler: this.scrollToPosition,
+    };
+
     if (this.props.renderMinimap) {
-      return (
-        <React.Fragment>
-          {this.props.renderMinimap({
-            vertices: this.props.vertices,
-            extremeX: Math.max(extremeX, width),
-            extremeY: Math.max(extremeY, height),
-            viewport: minimapViewport,
-            zoom,
-            changeScrollHandler: this.scrollToPosition,
-          })}
-        </React.Fragment>
-      );
+      return <React.Fragment>{this.props.renderMinimap(minimapProps)}</React.Fragment>;
     }
 
-    return (
-      <Minimap
-        vertices={this.props.vertices}
-        extremeX={Math.max(extremeX, width)}
-        extremeY={Math.max(extremeY, height)}
-        viewport={minimapViewport}
-        zoom={zoom}
-        changeScrollHandler={this.scrollToPosition}
-      />
-    );
+    return <Minimap {...minimapProps} />;
   }
 
   renderChildren(extremeX, extremeY, zoom) {


### PR DESCRIPTION
Accept a renderMinimap prop so that the user of the flowchart can define the styling of the mini-map by themselves.

If that prop is not provided, then the existing mini-map renderer will be used.